### PR TITLE
Try reduce false positives for pdf scan

### DIFF
--- a/maldoc_pdf.yar
+++ b/maldoc_pdf.yar
@@ -89,14 +89,20 @@ rule suspicious_embed : PDF raw
 rule PDF_NamedActions_Print_SaveAs_Close : PDF
 {
     meta:
-        description = "Detects PDF files with potentially suspicious named actions: /Print, /SaveAs, or /Close"
+        description = "Detects PDF files containing both suspicous launch actions and named actions: /Print, /SaveAs, or /Close"
         author = "JohanT"
         date = "2025-05-27"
         category = "pdf"
-        severity = "low"
-        reference = "PDF 1.7 (ISO 32000-1)"
 
     strings:
+		$magic = { 25 50 44 46 }
+		
+		$attrib0 = /\/Launch/
+		$attrib1 = /\/URL /
+		$attrib2 = /\/Action/
+		$attrib3 = /\/OpenAction/
+		$attrib4 = /\/F /
+	
         $named_action_print   = "/S /Named /N /Print"
 		$named_action_print2  = "/S/Named/N/Print"
         $named_action_saveas  = "/S /Named /N /SaveAs"
@@ -105,5 +111,7 @@ rule PDF_NamedActions_Print_SaveAs_Close : PDF
         $named_action_close2  = "/S/Named/N/Close"
 
     condition:
-        any of ($named_action*)
+		$magic in (0..1024) 
+		and any of ($attrib*)
+        and any of ($named_action*)
 }

--- a/maldoc_pdf.yar
+++ b/maldoc_pdf.yar
@@ -4,10 +4,10 @@ rule possible_exploit : PDF raw
 		author = "Glenn Edwards (@hiddenillusion)"
 		version = "0.1"
 		weight = 3
-		
+
 	strings:
 		$magic = { 25 50 44 46 }
-		
+
 		$attrib0 = /\/JavaScript /
 		$attrib3 = /\/ASCIIHexDecode/
 		$attrib4 = /\/ASCII85Decode/
@@ -17,7 +17,7 @@ rule possible_exploit : PDF raw
 		$shell = "A"
 		$cond0 = "unescape"
 		$cond1 = "String.fromCharCode"
-		
+
 		$nop = "%u9090%u9090"
 	condition:
 		$magic in (0..1024) and (2 of ($attrib*)) or ($action0 and #shell > 10 and 1 of ($cond*)) or ($action1 and $cond0 and $nop)
@@ -50,17 +50,17 @@ rule suspicious_js : PDF raw
 		author = "Glenn Edwards (@hiddenillusion)"
 		version = "0.1"
 		weight = 3
-		
+
 	strings:
 		$magic = { 25 50 44 46 }
-		
+
 		$attrib0 = /\/OpenAction /
 		$attrib1 = /\/JavaScript /
 
 		$js0 = "eval"
 		$js1 = "Array"
 		$js2 = "String.fromCharCode"
-		
+
 	condition:
 		$magic in (0..1024) and all of ($attrib*) and 2 of ($js*)
 }
@@ -72,16 +72,16 @@ rule suspicious_embed : PDF raw
 		version = "0.1"
 		ref = "https://feliam.wordpress.com/2010/01/13/generic-pdf-exploit-hider-embedpdf-py-and-goodbye-av-detection-012010/"
 		weight = 2
-		
+
 	strings:
 		$magic = { 25 50 44 46 }
-		
+
 		$meth0 = /\/Launch/
 		$meth1 = /\/GoTo(E|R)/ //means go to embedded or remote
 		$attrib0 = /\/URL /
 		$attrib1 = /\/Action/
 		$attrib2 = /\/Filespec/
-		
+
 	condition:
 		$magic in (0..1024) and 1 of ($meth*) and 2 of ($attrib*)
 }
@@ -95,23 +95,23 @@ rule PDF_NamedActions_Print_SaveAs_Close : PDF
         category = "pdf"
 
     strings:
-		$magic = { 25 50 44 46 }
-		
-		$attrib0 = /\/Launch/
-		$attrib1 = /\/URL /
-		$attrib2 = /\/Action/
-		$attrib3 = /\/OpenAction/
-		$attrib4 = /\/F /
-	
+        $magic = { 25 50 44 46 }
+
+        $attrib0 = /\/Launch/
+        $attrib1 = /\/URL /
+        $attrib2 = /\/Action/
+        $attrib3 = /\/OpenAction/
+        $attrib4 = /\/F /
+
         $named_action_print   = "/S /Named /N /Print"
-		$named_action_print2  = "/S/Named/N/Print"
+        $named_action_print2  = "/S/Named/N/Print"
         $named_action_saveas  = "/S /Named /N /SaveAs"
         $named_action_saveas2 = "/S/Named/N/SaveAs"
         $named_action_close   = "/S /Named /N /Close"
         $named_action_close2  = "/S/Named/N/Close"
 
     condition:
-		$magic in (0..1024) 
-		and any of ($attrib*)
+        $magic in (0..1024)
+        and any of ($attrib*)
         and any of ($named_action*)
 }


### PR DESCRIPTION
The `PDF_NamedActions_Print_SaveAs_Close` flags a couple of files per day as infected. See this [Datadog query](https://app.datadoghq.eu/event/explorer?query=bucketAV%20infected%20YARA.PDF_NamedActions_Print_SaveAs_Close.UNOFFICIAL&cols=&messageDisplay=expanded-lg&options=&refresh_mode=sliding&sort=DESC&view=all&from_ts=1746009468970&to_ts=1748601468970&live=true). 

This is an attempt to try to reduce eventual false positives by requiring presence of both NamedAction and launch action in the pdf in order to trigger.
